### PR TITLE
notebook to create and save spacy lemmas and vectors

### DIFF
--- a/exploration/data2lemma2vec.ipynb
+++ b/exploration/data2lemma2vec.ipynb
@@ -1,0 +1,367 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook contains the preprocesing of the 'tweet' column of `data/combined_deduped.csv` into lemmas and vectors using [spaCy](https://spacy.io).\n",
+    "\n",
+    "When run top to bottom, it creates four new CSV files in the data directory. These files contain the lemmas and vectors of the documents and are named `lemmas_<UTC DATETIME>.csv` and `vectors_[sm|md|lg]_<UTC DATETIME>.csv`, respectively. \n",
+    "\n",
+    "The lemmas CSV file contains separate columns for lemmas created with spaCy's `en-core-web-sm`, `en-core-web-md`, and `en-core-web-lg` models. These columns are named 'sm_lemmas', 'md_vectors', and 'lg_lemmas'.\n",
+    "\n",
+    "The vectors CSV files are separate files for vectors created with spaCy's `en-core-web-sm`, `en-core-web-md`, and `en-core-web-lg` models. These files are named 'vectors_sm_...', 'vectors_md_...', 'vectors_lg_...'. The vectors are in separate CSV files due to their large size.\n",
+    "\n",
+    "The CSV files will also contain the 'inappropriate' column from `combined_deduped.csv`.\n",
+    "\n",
+    "This notebook is intended to make preprocesing of the data that becomes necessary (stop words, normalizing, etc.) a standardized process that results in reproducible and trackable results.\n",
+    "\n",
+    "**NOTE:** This process takes 3+ hours on my local machine."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "CSV file sizes (approx.):\n",
+    "- lemmas: 44MB\n",
+    "- vectors_sm: 173MB\n",
+    "- vectors_md: 661MB\n",
+    "- vectors_lg: 661MB"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "\n",
+    "from datetime import datetime\n",
+    "\n",
+    "import spacy\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize spaCy models\n",
+    "\n",
+    "nlp_sm = spacy.load('en_core_web_sm')\n",
+    "nlp_md = spacy.load('en_core_web_md')\n",
+    "nlp_lg = spacy.load('en_core_web_lg')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load source training data\n",
+    "\n",
+    "training_data = pd.read_csv('data/combined_deduped.csv')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Lemmatization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Preprocessing for lemmatization\n",
+    "# add / remove stop words, normalize, any text processing as necessary\n",
+    "\n",
+    "# additional tokens to ignore\n",
+    "STOP_WORDS = []\n",
+    "\n",
+    "is_empty_pattern = re.compile(r'^\\s*$')\n",
+    "\n",
+    "def make_lemmas(nlp, docs):\n",
+    "    \"\"\"Creates a list of documents containing the lemmas of each document in the input docs.\n",
+    "\n",
+    "    :param nlp: spaCy NLP model to use\n",
+    "    :param docs: list of documents to lemmatize\n",
+    "\n",
+    "    :returns: list of lemmatized documents\n",
+    "    \"\"\"\n",
+    "    lemmas = []\n",
+    "    for doc in nlp.pipe(docs, batch_size=500):\n",
+    "        doc_lemmas = []\n",
+    "        for token in doc:\n",
+    "            if (\n",
+    "                not token.is_stop\n",
+    "                and not token.is_punct\n",
+    "                and token.pos_ != 'PRON'\n",
+    "                and not is_empty_pattern.match(token.text)\n",
+    "                and len(token.lemma_) > 2\n",
+    "                and token.lemma_ not in STOP_WORDS\n",
+    "            ):\n",
+    "                doc_lemmas.append(token.lemma_)\n",
+    "        lemmas.append(doc_lemmas)\n",
+    "    return lemmas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Lemmatization with en-core-web-sm\nLemmatization with en-core-web-md\nLemmatization with en-core-web-lg\n"
+    }
+   ],
+   "source": [
+    "# Create lemmas with each of the spaCy models\n",
+    "\n",
+    "lemmas = pd.DataFrame()\n",
+    "\n",
+    "print('Lemmatization with en-core-web-sm')\n",
+    "lemmas['sm_lemmas'] = make_lemmas(nlp_sm, training_data['tweet'])\n",
+    "\n",
+    "print('Lemmatization with en-core-web-md')\n",
+    "lemmas['md_lemmas'] = make_lemmas(nlp_md, training_data['tweet'])\n",
+    "\n",
+    "print('Lemmatization with en-core-web-lg')\n",
+    "lemmas['lg_lemmas'] = make_lemmas(nlp_lg, training_data['tweet'])\n",
+    "\n",
+    "lemmas['inappropriate'] = training_data['inappropriate']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Training data shape: (146264, 2)\nLemmas shape: (146264, 4)\n\n"
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "                                           sm_lemmas  \\\n0  [beat, Dr., Dre, urbeat, Wired, Ear, Headphone...   \n1  [@Papapishu, man, fucking, rule, party, perpet...   \n2  [time, draw, close, 128591;&#127995, Father, d...   \n3  [notice, start, act, different, distant, peep,...   \n4  [forget, unfollower, believe, grow, new, follo...   \n\n                                           md_lemmas  \\\n0  [beat, Dr., Dre, urbeat, Wired, ear, Headphone...   \n1  [@Papapishu, man, fucking, rule, party, perpet...   \n2  [time, draw, close, 128591;&#127995, Father, d...   \n3  [notice, start, act, different, distant, peep,...   \n4  [forget, unfollower, believe, grow, new, follo...   \n\n                                           lg_lemmas  inappropriate  \n0  [beat, Dr., Dre, urBeats, wire, Ear, Headphone...           True  \n1  [@Papapishu, man, fucking, rule, party, perpet...           True  \n2  [time, draw, close, 128591;&#127995, Father, d...          False  \n3  [notice, start, act, different, distant, peep,...          False  \n4  [forget, unfollower, believe, grow, new, follo...          False  ",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>sm_lemmas</th>\n      <th>md_lemmas</th>\n      <th>lg_lemmas</th>\n      <th>inappropriate</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>[beat, Dr., Dre, urbeat, Wired, Ear, Headphone...</td>\n      <td>[beat, Dr., Dre, urbeat, Wired, ear, Headphone...</td>\n      <td>[beat, Dr., Dre, urBeats, wire, Ear, Headphone...</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>[@Papapishu, man, fucking, rule, party, perpet...</td>\n      <td>[@Papapishu, man, fucking, rule, party, perpet...</td>\n      <td>[@Papapishu, man, fucking, rule, party, perpet...</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>[time, draw, close, 128591;&amp;#127995, Father, d...</td>\n      <td>[time, draw, close, 128591;&amp;#127995, Father, d...</td>\n      <td>[time, draw, close, 128591;&amp;#127995, Father, d...</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>[notice, start, act, different, distant, peep,...</td>\n      <td>[notice, start, act, different, distant, peep,...</td>\n      <td>[notice, start, act, different, distant, peep,...</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>[forget, unfollower, believe, grow, new, follo...</td>\n      <td>[forget, unfollower, believe, grow, new, follo...</td>\n      <td>[forget, unfollower, believe, grow, new, follo...</td>\n      <td>False</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "metadata": {},
+     "execution_count": 6
+    }
+   ],
+   "source": [
+    "# Quick glance verification of proper output\n",
+    "\n",
+    "print('Training data shape:', training_data.shape)\n",
+    "print('Lemmas shape:', lemmas.shape)\n",
+    "print()\n",
+    "lemmas.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Export Lemmas\n",
+    "\n",
+    "Create timestamp at this point to be used when exporting lemmas and vectors.\n",
+    "\n",
+    "Exporting lemmas to CSV at this point, because saving to CSV and reloading from that CSV with pandas ensures that all tokens in the docs are strings. This is the simplest method (quickest fix) I found to avoid a type error when vectorizing these lemmas."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Creating data/lemmas_2020-04-30-18-10-45Z.csv\n"
+    }
+   ],
+   "source": [
+    "# UTC datetime stamp to correlate lemmas and vectors to a specific run\n",
+    "\n",
+    "utc_now_formatted = datetime.utcnow().strftime(r'%Y-%m-%d-%H-%M-%SZ')\n",
+    "\n",
+    "lemmas_filename = f'data/lemmas_{utc_now_formatted}.csv'\n",
+    "\n",
+    "print(f'Creating {lemmas_filename}')\n",
+    "lemmas.to_csv(lemmas_filename, index=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Vectorization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Reload lemmas from csv\n",
+    "# This prevents a type error when parsing the lemmas for vectorization\n",
+    "\n",
+    "lemmas = pd.read_csv(lemmas_filename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_vectors(nlp, docs):\n",
+    "    \"\"\"Creates a list of documents containing the vectors of each document in the input docs.\n",
+    "\n",
+    "    :param nlp: spaCy NLP model to use\n",
+    "    :param docs: list of documents to vectorize\n",
+    "\n",
+    "    :returns: list of vectorized documents\n",
+    "    \"\"\"\n",
+    "    vectors = []\n",
+    "    for doc in nlp.pipe(docs, batch_size=500):\n",
+    "        vectors.append(doc.vector)\n",
+    "    return vectors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Vectorization with en-core-web-sm\nVectorization with en-core-web-md\nVectorization with en-core-web-md\n"
+    }
+   ],
+   "source": [
+    "# Create vectors of the lemmas with each of the spaCy models\n",
+    "\n",
+    "vectors = pd.DataFrame()\n",
+    "\n",
+    "print('Vectorization with en-core-web-sm')\n",
+    "vectors['sm_vectors'] = make_vectors(nlp_sm, lemmas['sm_lemmas'])\n",
+    "\n",
+    "print('Vectorization with en-core-web-md')\n",
+    "vectors['md_vectors'] = make_vectors(nlp_md, lemmas['md_lemmas'])\n",
+    "\n",
+    "print('Vectorization with en-core-web-lg')\n",
+    "vectors['lg_vectors'] = make_vectors(nlp_lg, lemmas['lg_lemmas'])\n",
+    "\n",
+    "vectors['inappropriate'] = training_data['inappropriate']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Training data shape: (146264, 2)\nVectors shape: (146264, 4)\n\n"
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "                                          sm_vectors  \\\n0  [-0.15469056, 0.94960415, -2.069193, 0.2554039...   \n1  [-0.16211522, 0.5824614, -1.6822865, -0.115870...   \n2  [-0.23576383, 0.645006, -1.8176227, -0.0978480...   \n3  [0.012096468, 0.84190094, -1.9023851, -0.28529...   \n4  [-0.2324229, 0.63849, -1.5870256, -0.25167158,...   \n\n                                          md_vectors  \\\n0  [-0.16546369, 0.44611606, 0.01917303, -0.06901...   \n1  [-0.23224233, 0.35610408, 0.03614007, -0.11104...   \n2  [-0.14492889, 0.41942063, -0.024495453, -0.062...   \n3  [-0.17496027, 0.4259231, -0.05608107, -0.11582...   \n4  [-0.1704493, 0.46021652, -0.011923886, -0.1096...   \n\n                                          lg_vectors  inappropriate  \n0  [-0.16230947, 0.46143216, 0.026662538, -0.0600...           True  \n1  [-0.23224233, 0.35610408, 0.03614007, -0.11104...           True  \n2  [-0.14492889, 0.41942063, -0.024495453, -0.062...          False  \n3  [-0.16725582, 0.42386648, -0.054639563, -0.116...          False  \n4  [-0.1704493, 0.46021652, -0.011923886, -0.1096...          False  ",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>sm_vectors</th>\n      <th>md_vectors</th>\n      <th>lg_vectors</th>\n      <th>inappropriate</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>[-0.15469056, 0.94960415, -2.069193, 0.2554039...</td>\n      <td>[-0.16546369, 0.44611606, 0.01917303, -0.06901...</td>\n      <td>[-0.16230947, 0.46143216, 0.026662538, -0.0600...</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>[-0.16211522, 0.5824614, -1.6822865, -0.115870...</td>\n      <td>[-0.23224233, 0.35610408, 0.03614007, -0.11104...</td>\n      <td>[-0.23224233, 0.35610408, 0.03614007, -0.11104...</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>[-0.23576383, 0.645006, -1.8176227, -0.0978480...</td>\n      <td>[-0.14492889, 0.41942063, -0.024495453, -0.062...</td>\n      <td>[-0.14492889, 0.41942063, -0.024495453, -0.062...</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>[0.012096468, 0.84190094, -1.9023851, -0.28529...</td>\n      <td>[-0.17496027, 0.4259231, -0.05608107, -0.11582...</td>\n      <td>[-0.16725582, 0.42386648, -0.054639563, -0.116...</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>[-0.2324229, 0.63849, -1.5870256, -0.25167158,...</td>\n      <td>[-0.1704493, 0.46021652, -0.011923886, -0.1096...</td>\n      <td>[-0.1704493, 0.46021652, -0.011923886, -0.1096...</td>\n      <td>False</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "metadata": {},
+     "execution_count": 25
+    }
+   ],
+   "source": [
+    "# Quick glance verification of proper output\n",
+    "\n",
+    "print('Training data shape:', training_data.shape)\n",
+    "print('Vectors shape:', vectors.shape)\n",
+    "print()\n",
+    "vectors.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Export vectors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Creating data/vectors_sm_2020-04-30-18-10-45Z.csv\nCreating data/vectors_md_2020-04-30-18-10-45Z.csv\nCreating data/vectors_lg_2020-04-30-18-10-45Z.csv\n"
+    }
+   ],
+   "source": [
+    "# Use the same UTC datetime stamp from when lemmas were exported\n",
+    "\n",
+    "vectors_sm_filename = f'data/vectors_sm_{utc_now_formatted}.csv'\n",
+    "vectors_md_filename = f'data/vectors_md_{utc_now_formatted}.csv'\n",
+    "vectors_lg_filename = f'data/vectors_lg_{utc_now_formatted}.csv'\n",
+    "\n",
+    "print(f'Creating {vectors_sm_filename}')\n",
+    "vectors[['sm_vectors', 'inappropriate']].to_csv(vectors_sm_filename, index=False)\n",
+    "\n",
+    "print(f'Creating {vectors_md_filename}')\n",
+    "vectors[['md_vectors', 'inappropriate']].to_csv(vectors_md_filename, index=False)\n",
+    "\n",
+    "print(f'Creating {vectors_lg_filename}')\n",
+    "vectors[['lg_vectors', 'inappropriate']].to_csv(vectors_lg_filename, index=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6-final"
+  },
+  "orig_nbformat": 2,
+  "kernelspec": {
+   "name": "python37664bitallaydspipenv9dc12dab3da348b6bc255254c19ea33e",
+   "display_name": "Python 3.7.6 64-bit ('allay-ds': pipenv)"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
# Description
Jupyter notebook that creates lemmas and vectors from the training data in 'data/combined_deduped.csv'.

Creates CSV files of all created data.

There is a [post in Slack](https://lambda-students.slack.com/archives/C011C2ZVABV/p1588279148048500) with the link to the files created with this run of the notebook.

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## Change Status
- [X] Complete, tested, ready to review and merge

# How Has This Been Tested?
- [X] Ran locally. Generated output files.

# Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts
