### PR TITLE
update - save as dataframes in compressed pickle format

### DIFF
--- a/exploration/data2lemma2vec.ipynb
+++ b/exploration/data2lemma2vec.ipynb
@@ -6,28 +6,41 @@
    "source": [
     "This notebook contains the preprocesing of the 'tweet' column of `data/combined_deduped.csv` into lemmas and vectors using [spaCy](https://spacy.io).\n",
     "\n",
-    "When run top to bottom, it creates four new CSV files in the data directory. These files contain the lemmas and vectors of the documents and are named `lemmas_<UTC DATETIME>.csv` and `vectors_[sm|md|lg]_<UTC DATETIME>.csv`, respectively. \n",
+    "When run top to bottom, it creates four new files in the data directory. These files contain the compressed, pickled dataframes for lemmas and vectors of the documents and are named `lemmas_<UTC DATETIME>.pkl.xz` and `vectors_[sm|md|lg]_<UTC DATETIME>.pkl.xz`, respectively. \n",
     "\n",
-    "The lemmas CSV file contains separate columns for lemmas created with spaCy's `en-core-web-sm`, `en-core-web-md`, and `en-core-web-lg` models. These columns are named 'sm_lemmas', 'md_vectors', and 'lg_lemmas'.\n",
+    "The lemmas file contains separate columns for lemmas created with spaCy's `en-core-web-sm`, `en-core-web-md`, and `en-core-web-lg` models. These columns are named 'sm_lemmas', 'md_vectors', and 'lg_lemmas'.\n",
     "\n",
-    "The vectors CSV files are separate files for vectors created with spaCy's `en-core-web-sm`, `en-core-web-md`, and `en-core-web-lg` models. These files are named 'vectors_sm_...', 'vectors_md_...', 'vectors_lg_...'. The vectors are in separate CSV files due to their large size.\n",
+    "The vectors files are separate files for vectors created with spaCy's `en-core-web-sm`, `en-core-web-md`, and `en-core-web-lg` models. These files are named 'vectors\\_sm\\_...', 'vectors\\_md\\_...', 'vectors\\_lg\\_...'. The vectors are in separate files due to their large size.\n",
     "\n",
-    "The CSV files will also contain the 'inappropriate' column from `combined_deduped.csv`.\n",
+    "The dataframes will also contain the 'inappropriate' column from `combined_deduped.csv`.\n",
     "\n",
     "This notebook is intended to make preprocesing of the data that becomes necessary (stop words, normalizing, etc.) a standardized process that results in reproducible and trackable results.\n",
     "\n",
-    "**NOTE:** This process takes 3+ hours on my local machine."
+    "**NOTE:** This process takes ~1.5 hours on my local machine."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "CSV file sizes (approx.):\n",
-    "- lemmas: 44MB\n",
-    "- vectors_sm: 173MB\n",
-    "- vectors_md: 661MB\n",
-    "- vectors_lg: 661MB"
+    "To load these files:\n",
+    "\n",
+    "```python\n",
+    "import pandas as pd\n",
+    "\n",
+    "df = pd.read_pickle(filename, compression='xz')\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "File sizes (approx.):\n",
+    "- lemmas: 12MB\n",
+    "- vectors_sm: 50MB\n",
+    "- vectors_md: 155MB\n",
+    "- vectors_lg: 15MB"
    ]
   },
   {
@@ -175,57 +188,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Export Lemmas\n",
-    "\n",
-    "Create timestamp at this point to be used when exporting lemmas and vectors.\n",
-    "\n",
-    "Exporting lemmas to CSV at this point, because saving to CSV and reloading from that CSV with pandas ensures that all tokens in the docs are strings. This is the simplest method (quickest fix) I found to avoid a type error when vectorizing these lemmas."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "Creating data/lemmas_2020-04-30-18-10-45Z.csv\n"
-    }
-   ],
-   "source": [
-    "# UTC datetime stamp to correlate lemmas and vectors to a specific run\n",
-    "\n",
-    "utc_now_formatted = datetime.utcnow().strftime(r'%Y-%m-%d-%H-%M-%SZ')\n",
-    "\n",
-    "lemmas_filename = f'data/lemmas_{utc_now_formatted}.csv'\n",
-    "\n",
-    "print(f'Creating {lemmas_filename}')\n",
-    "lemmas.to_csv(lemmas_filename, index=False)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Vectorization"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Reload lemmas from csv\n",
-    "# This prevents a type error when parsing the lemmas for vectorization\n",
-    "\n",
-    "lemmas = pd.read_csv(lemmas_filename)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -245,94 +213,72 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Vectorization with en-core-web-sm\nVectorization with en-core-web-md\nVectorization with en-core-web-md\n"
+     "text": "Vectorization with en-core-web-sm\n - shape: (146264, 97)\nVectorization with en-core-web-md\n - shape: (146264, 301)\nVectorization with en-core-web-lg\n - shape: (146264, 301)\n"
     }
    ],
    "source": [
-    "# Create vectors of the lemmas with each of the spaCy models\n",
-    "\n",
-    "vectors = pd.DataFrame()\n",
+    "# Create vectors of the documents with each of the spaCy models\n",
     "\n",
     "print('Vectorization with en-core-web-sm')\n",
-    "vectors['sm_vectors'] = make_vectors(nlp_sm, lemmas['sm_lemmas'])\n",
+    "vectors_sm = pd.DataFrame(make_vectors(nlp_sm, training_data['tweet']))\n",
+    "vectors_sm['inappropriate'] = training_data['inappropriate']\n",
+    "print(' - shape:', vectors_sm.shape)\n",
     "\n",
     "print('Vectorization with en-core-web-md')\n",
-    "vectors['md_vectors'] = make_vectors(nlp_md, lemmas['md_lemmas'])\n",
+    "vectors_md = pd.DataFrame(make_vectors(nlp_md, training_data['tweet']))\n",
+    "vectors_md['inappropriate'] = training_data['inappropriate']\n",
+    "print(' - shape:', vectors_md.shape)\n",
     "\n",
     "print('Vectorization with en-core-web-lg')\n",
-    "vectors['lg_vectors'] = make_vectors(nlp_lg, lemmas['lg_lemmas'])\n",
-    "\n",
-    "vectors['inappropriate'] = training_data['inappropriate']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {},
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "Training data shape: (146264, 2)\nVectors shape: (146264, 4)\n\n"
-    },
-    {
-     "output_type": "execute_result",
-     "data": {
-      "text/plain": "                                          sm_vectors  \\\n0  [-0.15469056, 0.94960415, -2.069193, 0.2554039...   \n1  [-0.16211522, 0.5824614, -1.6822865, -0.115870...   \n2  [-0.23576383, 0.645006, -1.8176227, -0.0978480...   \n3  [0.012096468, 0.84190094, -1.9023851, -0.28529...   \n4  [-0.2324229, 0.63849, -1.5870256, -0.25167158,...   \n\n                                          md_vectors  \\\n0  [-0.16546369, 0.44611606, 0.01917303, -0.06901...   \n1  [-0.23224233, 0.35610408, 0.03614007, -0.11104...   \n2  [-0.14492889, 0.41942063, -0.024495453, -0.062...   \n3  [-0.17496027, 0.4259231, -0.05608107, -0.11582...   \n4  [-0.1704493, 0.46021652, -0.011923886, -0.1096...   \n\n                                          lg_vectors  inappropriate  \n0  [-0.16230947, 0.46143216, 0.026662538, -0.0600...           True  \n1  [-0.23224233, 0.35610408, 0.03614007, -0.11104...           True  \n2  [-0.14492889, 0.41942063, -0.024495453, -0.062...          False  \n3  [-0.16725582, 0.42386648, -0.054639563, -0.116...          False  \n4  [-0.1704493, 0.46021652, -0.011923886, -0.1096...          False  ",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>sm_vectors</th>\n      <th>md_vectors</th>\n      <th>lg_vectors</th>\n      <th>inappropriate</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>[-0.15469056, 0.94960415, -2.069193, 0.2554039...</td>\n      <td>[-0.16546369, 0.44611606, 0.01917303, -0.06901...</td>\n      <td>[-0.16230947, 0.46143216, 0.026662538, -0.0600...</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>[-0.16211522, 0.5824614, -1.6822865, -0.115870...</td>\n      <td>[-0.23224233, 0.35610408, 0.03614007, -0.11104...</td>\n      <td>[-0.23224233, 0.35610408, 0.03614007, -0.11104...</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>[-0.23576383, 0.645006, -1.8176227, -0.0978480...</td>\n      <td>[-0.14492889, 0.41942063, -0.024495453, -0.062...</td>\n      <td>[-0.14492889, 0.41942063, -0.024495453, -0.062...</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>[0.012096468, 0.84190094, -1.9023851, -0.28529...</td>\n      <td>[-0.17496027, 0.4259231, -0.05608107, -0.11582...</td>\n      <td>[-0.16725582, 0.42386648, -0.054639563, -0.116...</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>[-0.2324229, 0.63849, -1.5870256, -0.25167158,...</td>\n      <td>[-0.1704493, 0.46021652, -0.011923886, -0.1096...</td>\n      <td>[-0.1704493, 0.46021652, -0.011923886, -0.1096...</td>\n      <td>False</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
-     },
-     "metadata": {},
-     "execution_count": 25
-    }
-   ],
-   "source": [
-    "# Quick glance verification of proper output\n",
-    "\n",
-    "print('Training data shape:', training_data.shape)\n",
-    "print('Vectors shape:', vectors.shape)\n",
-    "print()\n",
-    "vectors.head()"
+    "vectors_lg = pd.DataFrame(make_vectors(nlp_lg, training_data['tweet']))\n",
+    "vectors_lg['inappropriate'] = training_data['inappropriate']\n",
+    "print(' - shape:', vectors_lg.shape)\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Export vectors"
+    "## Export lemmas and vectors"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Creating data/vectors_sm_2020-04-30-18-10-45Z.csv\nCreating data/vectors_md_2020-04-30-18-10-45Z.csv\nCreating data/vectors_lg_2020-04-30-18-10-45Z.csv\n"
+     "text": "Creating data/lemmas_2020-05-04-16-27-18Z.pkl.xz\nCreating data/vectors_sm_2020-05-04-16-27-18Z.pkl.xz\nCreating data/vectors_md_2020-05-04-16-27-18Z.pkl.xz\nCreating data/vectors_lg_2020-05-04-16-27-18Z.pkl.xz\n"
     }
    ],
    "source": [
-    "# Use the same UTC datetime stamp from when lemmas were exported\n",
+    "# UTC datetime stamp to correlate lemmas and vectors to a specific run\n",
+    "utc_now_formatted = datetime.utcnow().strftime(r'%Y-%m-%d-%H-%M-%SZ')\n",
     "\n",
-    "vectors_sm_filename = f'data/vectors_sm_{utc_now_formatted}.csv'\n",
-    "vectors_md_filename = f'data/vectors_md_{utc_now_formatted}.csv'\n",
-    "vectors_lg_filename = f'data/vectors_lg_{utc_now_formatted}.csv'\n",
+    "lemmas_filename = f'data/lemmas_{utc_now_formatted}.pkl.xz'\n",
+    "vectors_sm_filename = f'data/vectors_sm_{utc_now_formatted}.pkl.xz'\n",
+    "vectors_md_filename = f'data/vectors_md_{utc_now_formatted}.pkl.xz'\n",
+    "vectors_lg_filename = f'data/vectors_lg_{utc_now_formatted}.pkl.xz'\n",
+    "\n",
+    "print(f'Creating {lemmas_filename}')\n",
+    "lemmas.to_pickle(lemmas_filename, compression='xz')\n",
     "\n",
     "print(f'Creating {vectors_sm_filename}')\n",
-    "vectors[['sm_vectors', 'inappropriate']].to_csv(vectors_sm_filename, index=False)\n",
+    "vectors_sm.to_pickle(vectors_sm_filename, compression='xz')\n",
     "\n",
     "print(f'Creating {vectors_md_filename}')\n",
-    "vectors[['md_vectors', 'inappropriate']].to_csv(vectors_md_filename, index=False)\n",
+    "vectors_md.to_pickle(vectors_md_filename, compression='xz')\n",
     "\n",
     "print(f'Creating {vectors_lg_filename}')\n",
-    "vectors[['lg_vectors', 'inappropriate']].to_csv(vectors_lg_filename, index=False)"
+    "vectors_lg.to_pickle(vectors_lg_filename, compression='xz')"
    ]
   },
   {


### PR DESCRIPTION
# Description
Pandas library would not correctly read the saved CSV files in previous version of notebook.
Files are now saved as compressed, pickled dataframes. This also benefits by using much less space than the CSV files.

To load these files:
```python
import pandas as pd

df = pd.read_pickle(filename, compression='xz')
```

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## Change Status
- [X] Complete, tested, ready to review and merge

# How Has This Been Tested?
- [X] Saved and loaded files successfully locally and in colab

# Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts
