### PR TITLE
remove 'due by week #' labels in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Allay project is [deployed on Heroku](https://labs21-allay-fe.herokuapp.com/
 
 The data science content moderation API is [deployed on Heroku](https://allay23-staging-ds.herokuapp.com/docs).
 
-## 5️⃣ Contributors
+## Contributors
 
 
 |[Alex Jenkins-Neary](http://www.alexjenkinsneary.com)|[Caleb Spraul](https://jcs-lambda.github.io)|[Andrew Archie](https://baiganking.github.io)|
@@ -77,13 +77,13 @@ This gets broken down into numerical features which are then modeled.
 
 [Baseline Neural Network models](./exploration/train_nn_models.ipynb)
 
-### 3️⃣ How to connect to the web API
+### How to connect to the web API
 
 [Allay Frontend](https://github.com/Lambda-School-Labs/allay-fe)
 
 [Allay Backend](https://github.com/Lambda-School-Labs/allay-be)
 
-### 3️⃣ How to connect to the data API
+### How to connect to the data API
 
 [Allay DS API Documentation](https://allay-ds.herokuapp.com/docs)
 


### PR DESCRIPTION
# Description
Remove the numeric emojis indicating which week a section was due left over from the template.

## Type of change
- [X] This change is a documentation update

## Change Status
- [X] Complete, tested, ready to review and merge

# How Has This Been Tested?
- [X] Looked at it, emojis are gone.

# Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My code has been reviewed by at least one peer
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts
